### PR TITLE
char: random: Fix Deep Sleep issue

### DIFF
--- a/drivers/char/random.c
+++ b/drivers/char/random.c
@@ -1897,7 +1897,7 @@ void add_hwgenerator_randomness(const char *buffer, size_t count,
 		 * random_write_wakeup_thresh, or when the calling
 		 * thread is about to terminate.
 		 */
-		wait_event_interruptible(random_write_wait,
+		wait_event_freezable(random_write_wait,
 					 kthread_should_stop() ||
 			ENTROPY_BITS(&input_pool) <= random_write_wakeup_bits);
 	}


### PR DESCRIPTION
Device has been reported to not enter Deep Sleep state at all due to upstreaming, turned out it's caused by a change in f41fc0bfede5 "random: initialize the non-blocking pool via add_hwgenerator_randomness()"

Fix this issue by choosing 'wait_event_freezable' instead of 'wait_event_interruptible'